### PR TITLE
Split implementation of device and host side components.

### DIFF
--- a/firmware/computer.c
+++ b/firmware/computer.c
@@ -698,6 +698,7 @@ static inline void computer_data_set_talk(uint8_t comp, comp_device *dev,
 		uint8_t reg, uint8_t *data, uint8_t data_len, bool keep)
 {
 	if (data_len < 2) data_len = 0;
+	if (!data) data_len = 0;
 
 	// copy data
 	for (uint8_t i = 0; i < data_len; i++) {
@@ -759,7 +760,7 @@ bool computer_data_offer(uint8_t comp, uint8_t drv_idx, uint8_t reg,
 	if (data_len > 8 || data_len < 2) return false;
 
 	comp_device *dev = &computers[comp].devices[drv_idx];
-	if (sem_acquire_timeout_us(&dev->sem, 1000)) {
+	if (sem_acquire_timeout_us(&dev->sem, COMPUTER_DATA_OFFER_TIMEOUT)) {
 		// if there is data in there, do not overwrite
 		if (dev->talk[reg].length > 0) {
 			sem_release(&dev->sem);
@@ -783,7 +784,7 @@ bool computer_data_set(uint8_t comp, uint8_t drv_idx, uint8_t reg,
 	if (reg > 2) return false;
 
 	comp_device *dev = &computers[comp].devices[drv_idx];
-	if (sem_acquire_timeout_us(&dev->sem, 1000)) {
+	if (sem_acquire_timeout_us(&dev->sem, COMPUTER_DATA_OFFER_TIMEOUT)) {
 		computer_data_set_talk(comp, dev, reg, data, data_len, keep);
 		sem_release(&dev->sem);
 		return true;

--- a/firmware/computer.h
+++ b/firmware/computer.h
@@ -27,12 +27,17 @@
 #include "driver.h"
 
 /**
+ * Amount of time, in microseconds, to block during _offer() and _set() calls.
+ */
+#define COMPUTER_DATA_OFFER_TIMEOUT  1000
+
+/**
  * Places new data into the given Talk register if no existing data is present.
  *
- * This will wait for a short time if the register in question is in use due to
- * an ongoing Talk operation. If it times out it will return false. It will
- * also return false if there is existing data in the register that has not
- * yet been sent.
+ * This may block for up to COMPUTER_DATA_OFFER_TIMEOUT milliseconds if the
+ * register in question is in use due to an ongoing Talk operation. If it times
+ * out it will return false. It will also return false if there is existing
+ * data in the register that has not yet been sent.
  *
  * @param computer  the computer index to assign for.
  * @param drv_idx   the index that your driver/device assignment was originally
@@ -62,7 +67,7 @@ bool computer_data_offer(uint8_t comp, uint8_t drv_idx, uint8_t reg,
  * @param drv_idx   the index that your driver/device assignment was originally
  *                  given during registration.
  * @param reg       the Talk register to assign, from 0-2.
- * @param data      the data to assign.
+ * @param data      the data to assign, may be NULL to clear kept data.
  * @param data_len  the length of the data to assign, from 0-8; anything less
  *                  than 2 will result in existing data being destroyed.
  * @param keep      if true, preserve data in the register between Talks.

--- a/firmware/drivers/CMakeLists.txt
+++ b/firmware/drivers/CMakeLists.txt
@@ -3,5 +3,6 @@ cmake_minimum_required(VERSION 3.13)
 target_sources(hootswitch PRIVATE
 		joystick.c kensington.c
 		keyboard.c keyboard_handler.c
-		mouse.c serial.c
+		mouse.c mouse_handler.c
+		serial.c
 		)

--- a/firmware/drivers/CMakeLists.txt
+++ b/firmware/drivers/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 target_sources(hootswitch PRIVATE
-		joystick.c kensington.c keyboard.c mouse.c serial.c
+		joystick.c kensington.c
+		keyboard.c keyboard_handler.c
+		mouse.c serial.c
 		)

--- a/firmware/drivers/CMakeLists.txt
+++ b/firmware/drivers/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 
 target_sources(hootswitch PRIVATE
-		joystick.c kensington.c
+		joystick.c joystick_handler.c
+		kensington.c
 		keyboard.c keyboard_handler.c
 		mouse.c mouse_handler.c
 		serial.c

--- a/firmware/drivers/joystick.c
+++ b/firmware/drivers/joystick.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 saybur
+ * Copyright (C) 2024-2026 saybur
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,51 +24,27 @@
 #include "computer.h"
 #include "debug.h"
 #include "driver.h"
-#include "handler.h"
 #include "hardware.h"
-#include "host.h"
-#include "host_err.h"
-#include "host_sync.h"
+#include "util.h"
 
 #include "joystick.h"
 
 /*
  * Driver for ADB joysticks following the Gravis protocol. There are two
- * handlers supported: 0x4E (Firebird/Blackhawk) and 0x23 (Mousestick). These
- * are described in good detail here:
+ * handlers supported: 0x4E (Firebird/Blackhawk) and 0x23 (Mousestick II, using
+ * the 3-byte format only). These are described in good detail here:
  *
  * <https://github.com/lampmerchant/tashnotes/tree/main/macintosh/adb/protocols>
- *
- * The following assumes familiarity with the above description.
- *
- * The Firebird/Blackhawk is straightforward, this driver just echoes the
- * same information given by the joystick position data.
- *
- * The Mousestick always reports as a 0x0400 (3-byte protocol) device and only
- * supports that type of physical joystick. This is hopefully temporary and I
- * plan to support 0x0300 in the future.
- *
- * TODO this needs cross-joystick handling added (Firebird <-> Mousestick
- * conversion).
  */
 
 #define DEFAULT_ADDRESS 3
 #define DEFAULT_HANDLER 1
-#define MAX_DEVICES 2
-
-typedef enum {
-	MODE_INVALID = 0,
-	MODE_FIREBIRD,
-	MODE_MOUSESTICK
-} device_mode;
+#define MAX_DEVICES 3
 
 typedef struct {
-	uint8_t hdev;
-	uint8_t hdhi;
 	uint8_t drv_idx;
+	joystick_mode mode;
 	uint8_t dhi[COMPUTER_COUNT];
-	device_mode mode;
-	uint8_t reg1[3];    // register 1 from physical device
 } joystick;
 
 static volatile uint8_t active = 255;
@@ -85,20 +61,25 @@ static void drvr_reset(uint8_t comp, uint32_t ref)
 {
 	devices[ref].dhi[comp] = DEFAULT_HANDLER;
 
-	uint8_t reg1_len;
+	// Mac driver will ignore us if this isn't set early
+	uint8_t reg1[3];
+	uint8_t reg1_len = 0;
 	switch (devices[ref].mode) {
 		case MODE_FIREBIRD:
+			reg1[0] = 0x0A;
+			reg1[1] = 0x01;
+			reg1[2] = 0x30;
 			reg1_len = 3;
 			break;
 		case MODE_MOUSESTICK:
+			reg1[0] = 0x04;
+			reg1[1] = 0x00;
 			reg1_len = 2;
 			break;
-		default:
-			return;
 	}
-
-	computer_data_set(comp, devices[ref].drv_idx, 1,
-			devices[ref].reg1, reg1_len, true);
+	if (reg1_len > 0) {
+		computer_data_set(comp, devices[ref].drv_idx, 1, reg1, reg1_len, true);
+	}
 }
 
 static void drvr_switch(uint8_t comp)
@@ -113,16 +94,28 @@ static void drvr_get_handle(uint8_t comp, uint32_t ref, uint8_t *hndl)
 
 static void drvr_set_handle(uint8_t comp, uint32_t ref, uint8_t hndl)
 {
-	if (hndl == 0x01
-			|| hndl == 0x23
-			|| hndl == 0x4E) {
-		devices[ref].dhi[comp] = hndl;
+	joystick *dev = &devices[ref];
 
-		if (hndl == 0x4E) {
-			uint8_t data[8] = { 0xFF, 0xFF, 0xFF, 0x7F, 0x7F, 0x00, 0x00, 0x00 };
-			computer_data_set(comp, devices[ref].drv_idx, 0,
-					data, sizeof(data), false);
-		}
+	switch (devices[ref].mode) {
+		case MODE_FIREBIRD:
+			if (hndl == DEFAULT_HANDLER || hndl == MODE_FIREBIRD) {
+				dev->dhi[comp] = hndl;
+				dbg("gjoy %d set to dhid %d", ref, hndl);
+				if (hndl == MODE_FIREBIRD) {
+					// driver expects data immediately, push something for Talk0
+					uint8_t reg0[8] = { 0xFF, 0xFF, 0xFF, 0x7F, 0x7F, 0x00, 0x00, 0x00 };
+					computer_data_set(comp, dev->drv_idx,
+							0, reg0, sizeof(reg0), false);
+				}
+			}
+			break;
+
+		case MODE_MOUSESTICK:
+			if (hndl == DEFAULT_HANDLER || hndl == MODE_MOUSESTICK) {
+				dev->dhi[comp] = hndl;
+				dbg("gjoy %d set to dhid %d", ref, hndl);
+			}
+			break;
 	}
 }
 
@@ -137,199 +130,56 @@ static dev_driver joystick_driver = {
 	.set_handle_func = drvr_set_handle
 };
 
-/*
- * ----------------------------------------------------------------------------
- * --- Handler for the Physical Device ----------------------------------------
- * ----------------------------------------------------------------------------
- */
-
-static bool hndl_interview(volatile ndev_info *info, bool (*handle_change)(uint8_t, bool))
+bool joystick_register(uint8_t *id, joystick_mode mode)
 {
 	if (device_count >= MAX_DEVICES) return false;
-	if (info->address_def != DEFAULT_ADDRESS) return false;
 
-	// try supported device handlers
-	uint8_t handle = 0;
-	if (handle_change(0x4E, true)) {
-		// Firebird/Blackhawk
-		handle = 0x4E;
-	} else if (handle_change(0x23, true)) {
-		// Mousestick II
-		handle = 0x23;
-	} else {
-		// unsupported device
-		return false;
-	}
+	*id = device_count++;
+	joystick *dev = &devices[*id];
+	dev->mode = mode;
 
-	// setup storage
-	joystick *dev = &devices[device_count];
-	dev->hdev = info->hdev;
-
-	// read register 1 to determine specific model info
-	uint8_t dev_reg1[8];
-	uint8_t dev_reg1_len;
-	host_sync_cmd(info->hdev, COMMAND_TALK_1, dev_reg1, &dev_reg1_len);
-	switch (handle) {
-		case 0x4E:
-			if (dev_reg1_len == 3) {
-				// allow all possible variants reported by device
-				memcpy(dev->reg1, dev_reg1, 3);
-				dev->mode = MODE_FIREBIRD;
-			} else {
-				// not valid extended response, reset to original handler
-				dbg_err("gjoy: dev %d dhid 0x4e bad reg1", info->hdev);
-				handle_change(info->dhid_def, true);
-				return false;
-			}
-			break;
-		case 0x23:
-			if (dev_reg1_len == 2 && dev_reg1[0] == 0x04) {
-				// only support 0x0400 for 3-byte for the moment
-				memcpy(dev->reg1, dev_reg1, 2);
-				dev->mode = MODE_MOUSESTICK;
-			} else {
-				// not valid extended response, reset to original handler
-				dbg_err("gjoy: dev %d dhid 0x23 bad reg1", info->hdev);
-				handle_change(info->dhid_def, true);
-				return false;
-			}
-			break;
-		default:
-			dbg_err("gjoy: coding error reg1 %d", handle);
-			return false;
-	}
-
-	// for emulation, start at device handler 1 until changed
-	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
-		dev->dhi[c] = DEFAULT_HANDLER;
-	}
-
-	driver_register(&dev->drv_idx, &joystick_driver, device_count);
-	device_count++;
-	return true;
+	return driver_register(&dev->drv_idx, &joystick_driver, *id);
 }
 
-static void hndl_talk(uint8_t hdev, host_err err, uint32_t cid, uint8_t reg,
-		uint8_t *data, uint8_t data_len)
+void joystick_update(uint8_t id, joystick_data *jdata)
 {
-	// ignore until there is a computer to send data to
 	if (active >= COMPUTER_COUNT) return;
+	if (id >= device_count) return;
 
-	// select the correct device mapping
-	uint8_t i;
-	for (i = 0; i < device_count; i++) {
-		if (devices[i].hdev == hdev) break;
-	}
-	if (i == device_count) return;
-
-	// we only use register 0
-	if (reg != 0) {
-		dbg_err("gjoy: reg %d, ignoring", reg);
-		return;
-	}
-
-	// verify input data is satisfactory
-	switch (devices[i].mode) {
-		case MODE_FIREBIRD:
-			if (data_len != 8) {
-				dbg_err("gjoy: r0 len != 8, %d", data_len);
-				return;
-			}
-			break;
-		case MODE_MOUSESTICK:
-			// TODO this needs to be reworked for 0x0300 support in the future
-			if (data_len != 3) {
-				dbg_err("gjoy: r0 len != 3, %d", data_len);
-				return;
-			}
-			break;
-		default:
-			dbg_err("gjoy: r0 talk bug");
-			return;
-	}
+	dbg("gjoy %d: x1:%d, y1:%d, x2:%d, y2:%d btn:%d",
+			id, jdata->x1, jdata->y1, jdata->x2, jdata->y2, jdata->buttons);
 
 	// remap data from the real device to the virtual handler
 	uint8_t odata[8];
 	uint8_t odata_len;
-	switch (devices[i].dhi[active]) {
-		case 0x4E:
-			if (devices[i].mode == MODE_FIREBIRD) {
-				// already in correct format
-				memcpy(odata, data, data_len);
-				odata_len = data_len;
-			} else if (devices[i].mode == MODE_MOUSESTICK) {
-				// translate from Firebird->Mousestick
-				// TODO IMPLEMENT
-				dbg("gjoy: unimplemented");
-				return;
-			} else {
-				dbg_err("gjoy: remap bug!");
-				return;
-			}
+	switch (devices[id].dhi[active]) {
+		case MODE_FIREBIRD:
+			odata[0] = ((jdata->buttons) >> 16) & 0xFF;
+			odata[1] = ((jdata->buttons) >> 8) & 0xFF;
+			odata[2] = (jdata->buttons) & 0xFF;
+			odata[3] = jdata->x1 + 0x80;
+			odata[4] = jdata->y1 + 0x80;
+			odata[5] = jdata->y2 + 0x80;
+			odata[6] = jdata->x2 + 0x80;
+			odata[7] = 0;
+			odata_len = 8;
 			break;
-		case 0x23:
-			if (devices[i].mode == MODE_FIREBIRD) {
-				// translate from Mousestick->Firebird
-				// TODO IMPLEMENT
-				dbg("gjoy: unimplemented");
-				return;
-			} else if (devices[i].mode == MODE_MOUSESTICK) {
-				// already in correct format
-				memcpy(odata, data, data_len);
-				odata_len = data_len;
-			} else {
-				dbg_err("gjoy: remap bug!");
-				return;
-			}
+		case MODE_MOUSESTICK:
+			odata[0] = jdata->x1 + 0x80;
+			odata[1] = jdata->y1 + 0x80;
+			odata[2] = (jdata->buttons) & 0xFF;
+			odata_len = 3;
 			break;
 		default:
-			bool button;
-			int8_t x, y;
-			if (devices[i].mode == MODE_FIREBIRD) {
-				// translate from Firebird->Mouse
-				button = false;
-				if (data[0] != 0xFF || data[1] != 0xFF || data[2] != 0xFF) {
-					button = true;
-				}
-				x = (data[3] - 0x80);
-				y = (data[4] - 0x80);
-			} else if (devices[i].mode == MODE_MOUSESTICK) {
-				// translate from Mousestick->Mouse
-				button = false;
-				if (data[2] != 0xFF) {
-					button = true;
-				}
-				x = (data[0] - 0x80);
-				y = (data[1] - 0x80);
-			} else {
-				dbg_err("gjoy: remap bug!");
-				return;
-			}
+			int8_t x = jdata->x1;
+			int8_t y = jdata->y1;
 			// decrease mouse movement radius to avoid wild pointer behavior
-			x /= 8;
-			y /= 8;
+			uint8_t rshift = 3;
 			// store as mouse movement
-			odata[0] = (y & 0x7F) | (button ? 0x00 : 0x80);
-			odata[1] = (x & 0x7F) | 0x80;
+			util_mouse_encode(odata, rshift, x, y, jdata->buttons);
 			odata_len = 2;
-
-			dbg("gjoy: %d %d", odata[0], odata[1]);
 	}
 
 	// store input data directly into the response registers
-	computer_data_set(active, devices[i].drv_idx, 0, odata, odata_len, false);
-}
-
-static ndev_handler joystick_handler = {
-	.name = "gjoy",
-	.accept_noop_talks = false,
-	.interview_func = hndl_interview,
-	.talk_func = hndl_talk,
-	.listen_func = NULL,
-	.flush_func = NULL
-};
-
-void joystick_init(void)
-{
-	handler_register(&joystick_handler);
+	computer_data_set(active, devices[id].drv_idx, 0, odata, odata_len, false);
 }

--- a/firmware/drivers/joystick.h
+++ b/firmware/drivers/joystick.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 saybur
+ * Copyright (C) 2024-2026 saybur
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,52 @@
 #ifndef __JOYSTICK_H__
 #define __JOYSTICK_H__
 
-void joystick_init(void);
+typedef enum {
+	MODE_INVALID = 0,
+	MODE_FIREBIRD = 0x4E,
+	MODE_MOUSESTICK = 0x23
+} joystick_mode;
+
+/**
+ * A snapshot of position and button data from a joystick. There are several
+ * quirks to this format due to the underlying devices being emulated.
+ *
+ * 1) Position data is -128 == full up/left, 127 == full down/right, 0 center.
+ * 2) Least significant bit of button data is button 1.
+ * 3) Buttons follow the usual ADB convention where set (1) is up and cleared
+ *    (0) is pressed.
+ */
+typedef struct {
+	int8_t x1, y1;
+	int8_t x2, y2;
+	uint32_t buttons;
+} joystick_data;
+
+/**
+ * Registers a computer-facing keyboard and assigns it for exclusive use to
+ * the caller.
+ *
+ * @param *id            on success, set to the ID that should be used during
+ *                       enqueue operations.
+ * @param mode           the preferred joystick mode to be used for emulation
+ *                       (all devices start as fallback mouse/keyboards).
+ * @return               true if registration was successful, false otherwise.
+ */
+bool joystick_register(uint8_t *id, joystick_mode mode);
+
+/**
+ * Updates joystick position and button information and sets it in the active
+ * computer immediately for sending during the next ADB Talk opportunity.
+ *
+ * Not all data fields may be used, depending on the device being emulated
+ * and/or the current state of the particular computer's device handler ID.
+ * This tries to degrade cleanly where possible. In general, users are
+ * encouraged to just send as much data as possible and let the function try to
+ * sort it out.
+ *
+ * @param id      the ID provided at registration time.
+ * @param *jdata  the data to apply, as above.
+ */
+void joystick_update(uint8_t id, joystick_data *jdata);
 
 #endif /* __JOYSTICK_H__ */

--- a/firmware/drivers/joystick_handler.c
+++ b/firmware/drivers/joystick_handler.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2024-2026 saybur
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+#include "pico/stdlib.h"
+
+#include "FreeRTOS.h"
+
+#include "debug.h"
+#include "handler.h"
+#include "hardware.h"
+#include "host.h"
+#include "host_err.h"
+#include "host_sync.h"
+
+#include "joystick.h"
+#include "joystick_handler.h"
+
+/*
+ * Driver for physical ADB joysticks following the Gravis protocol.
+ */
+
+#define DEFAULT_ADDRESS 3
+#define MAX_DEVICES 2
+
+typedef struct {
+	uint8_t hdev;
+	uint8_t idx;
+	joystick_mode mode;
+} joystick;
+
+static joystick devices[MAX_DEVICES];
+static uint8_t device_count;
+
+/*
+ * ----------------------------------------------------------------------------
+ * --- Handler for the Physical Device ----------------------------------------
+ * ----------------------------------------------------------------------------
+ */
+
+static bool hndl_interview(volatile ndev_info *info, bool (*handle_change)(uint8_t, bool))
+{
+	if (device_count >= MAX_DEVICES) return false;
+	if (info->address_def != DEFAULT_ADDRESS) return false;
+
+	// try supported device handlers
+	uint8_t handle = 0;
+	if (handle_change(MODE_FIREBIRD, true)) {
+		// Firebird/Blackhawk
+		handle = MODE_FIREBIRD;
+	} else if (handle_change(MODE_MOUSESTICK, true)) {
+		// Mousestick II
+		handle = MODE_MOUSESTICK;
+	} else {
+		// unsupported device
+		return false;
+	}
+
+	// setup storage
+	joystick *dev = &devices[device_count];
+	dev->hdev = info->hdev;
+
+	// read register 1 to determine specific model info
+	uint8_t dev_reg1[8];
+	uint8_t dev_reg1_len;
+	host_sync_cmd(info->hdev, COMMAND_TALK_1, dev_reg1, &dev_reg1_len);
+	switch (handle) {
+		case MODE_FIREBIRD:
+			if (dev_reg1_len == 3) {
+				// allow all variants reported by device
+				dev->mode = MODE_FIREBIRD;
+			} else {
+				// not valid extended response, reset to original handler
+				dbg_err("gjoy: dev %d dhid 0x4e bad reg1", info->hdev);
+				handle_change(info->dhid_def, true);
+				return false;
+			}
+			break;
+
+		case MODE_MOUSESTICK:
+			if (dev_reg1_len == 2 && dev_reg1[0] == 0x04) {
+				// only support 0x0400 for 3-byte for the moment
+				dev->mode = MODE_MOUSESTICK;
+			} else {
+				// not valid extended response, reset to original handler
+				dbg_err("gjoy: dev %d dhid 0x23 bad reg1", info->hdev);
+				handle_change(info->dhid_def, true);
+				return false;
+			}
+			break;
+
+		default:
+			dbg_err("gjoy: coding error reg1 %d", handle);
+			return false;
+	}
+
+	if (joystick_register(&dev->idx, dev->mode)) {
+		device_count++;
+		return true;
+	} else {
+		dbg_err("gjoy: too many joysticks!");
+		handle_change(info->dhid_def, true);
+		return false;
+	}
+}
+
+static void hndl_talk(uint8_t hdev, host_err err, uint32_t cid, uint8_t reg,
+		uint8_t *data, uint8_t data_len)
+{
+	// select the correct device mapping
+	uint8_t i;
+	for (i = 0; i < device_count; i++) {
+		if (devices[i].hdev == hdev) break;
+	}
+	if (i == device_count) return;
+
+	// we only use register 0
+	if (reg != 0) {
+		dbg_err("gjoy: reg %d, ignoring", reg);
+		return;
+	}
+
+	// remap data to the intermediate format
+	joystick_data jdata;
+	switch (devices[i].mode) {
+		case MODE_FIREBIRD:
+			if (data_len != 8) {
+				dbg_err("gjoy: r0 len != 8, %d", data_len);
+				return;
+			}
+			jdata.buttons = 0xFF000000L
+					| ((uint32_t) (data[0] << 16))
+					| ((uint32_t) (data[1] << 8))
+					| ((uint32_t) data[2]);
+			jdata.x1 = ((int16_t) data[3]) - 0x80;
+			jdata.y1 = ((int16_t) data[4]) - 0x80;
+			jdata.y2 = ((int16_t) data[5]) - 0x80;
+			jdata.x2 = ((int16_t) data[6]) - 0x80;
+			break;
+
+		case MODE_MOUSESTICK:
+			// TODO this needs to be reworked for 0x0300 support in the future
+			if (data_len != 3) {
+				dbg_err("gjoy: r0 len != 3, %d", data_len);
+				return;
+			}
+			jdata.x1 = ((int16_t) data[0]) - 0x80;
+			jdata.y1 = ((int16_t) data[1]) - 0x80;
+			jdata.buttons = 0xFFFFFF00L
+					| ((uint32_t) data[3]);
+			break;
+
+		default:
+			// we don't run any joysticks in mouse mode, this is a bug!
+			dbg_err("gjoy: r0 talk bug");
+			return;
+	}
+
+	joystick_update(devices[i].idx, &jdata);
+}
+
+static ndev_handler joystick_handler = {
+	.name = "gjoy",
+	.accept_noop_talks = false,
+	.interview_func = hndl_interview,
+	.talk_func = hndl_talk,
+	.listen_func = NULL,
+	.flush_func = NULL
+};
+
+void joystick_handler_init(void)
+{
+	handler_register(&joystick_handler);
+}

--- a/firmware/drivers/joystick_handler.h
+++ b/firmware/drivers/joystick_handler.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024-2026 saybur
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef __JOYSTICK_HANDLER_H__
+#define __JOYSTICK_HANDLER_H__
+
+void joystick_handler_init(void);
+
+#endif /* __JOYSTICK_HANDLER_H__ */

--- a/firmware/drivers/kensington.c
+++ b/firmware/drivers/kensington.c
@@ -233,7 +233,7 @@ static void drvr_talk(uint8_t comp, uint32_t ref, uint8_t reg, bool pri)
 	if (reg == 0 && xSemaphoreTake(mice[ref].sem, portMAX_DELAY)) {
 		if (mice[ref].pending) {
 
-			util_mouse_encode(data, mice[ref].x, mice[ref].y, mice[ref].buttons);
+			util_mouse_encode(data, 0, mice[ref].x, mice[ref].y, mice[ref].buttons);
 			len = (extended || pri) ? 3 : 2;
 			if (computer_data_offer(active, drv_idx, 0, data, len)) {
 				mice[ref].pending = false;
@@ -463,7 +463,7 @@ static void hndl_talk(uint8_t hdev, host_err err, uint32_t cid, uint8_t reg,
 
 			// encode the resulting output
 			uint8_t data_out[5];
-			util_mouse_encode(data_out, xt, yt, buttons);
+			util_mouse_encode(data_out, 0, xt, yt, buttons);
 
 			// try to send data, or if send can't be done, store
 			if (computer_data_offer(active, drv_idx, 0,

--- a/firmware/drivers/keyboard.c
+++ b/firmware/drivers/keyboard.c
@@ -338,6 +338,8 @@ void keyboard_enqueue(uint8_t id, keyboard_message *m)
 	uint8_t hi = m->data[1];
 	uint8_t lo = m->data[0];
 
+	dbg("kbd: lo:0x%02X, hi:0x%02X", lo, hi);
+
 	// handle power switch activation
 	if (lo == 0x7F && hi == 0x7F) {
 		computer_psw(active, true);
@@ -387,7 +389,18 @@ void keyboard_enqueue(uint8_t id, keyboard_message *m)
 bool keyboard_register(uint8_t *id, void (*reg2_callback)(uint8_t, uint16_t))
 {
 	if (keyboard_count >= MAX_KEYBOARDS) return false;
-	keyboards[keyboard_count].reg2_callback = reg2_callback;
+
 	*id = keyboard_count++;
-	return driver_register(&(keyboards[*id].drv_idx), &keyboard_driver, *id);
+	keyboard *kbd = &keyboards[*id];
+
+	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
+		kbd->mem[c].dhi = 0x02;
+		kbd->mem[c].queue = xQueueCreate(KEYBOARD_QUEUE_DEPTH,
+				sizeof(keyboard_message));
+		assert(kbd->mem[c].queue != NULL);
+		kbd->mem[c].reg2 = DEFAULT_REGISTER_2;
+	}
+
+	kbd->reg2_callback = reg2_callback;
+	return driver_register(&kbd->drv_idx, &keyboard_driver, *id);
 }

--- a/firmware/drivers/keyboard.c
+++ b/firmware/drivers/keyboard.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 saybur
+ * Copyright (C) 2024-2026 saybur
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,14 +23,17 @@
 #include "computer.h"
 #include "debug.h"
 #include "driver.h"
-#include "handler.h"
 #include "hardware.h"
-#include "host.h"
-#include "host_err.h"
 
 #include "keyboard.h"
 
-// sets the most number of passthru keyboards permitted
+/*
+ * Driver (computer-side) implementation of an extended ADB keyboard.
+ *
+ * TODO: evaluate the extended part of this implementation for errors.
+ */
+
+// maximum number of supported computer-facing keyboards
 #define MAX_KEYBOARDS         4
 
 // how many Talk 0s from a keyboard are queued for sending to computers?
@@ -93,23 +96,17 @@ const uint8_t codes_to_comp_idx[] = {
 };
 
 typedef struct {
-	uint8_t length;
-	uint8_t data[2];
-} keyboard_message;
-
-typedef struct {
 	uint8_t dhi;
 	QueueHandle_t queue;
 	uint16_t reg2;
 } keyboard_memory;
 
 typedef struct {
-	uint8_t hdev;
 	uint8_t drv_idx;
-	bool extended;
 	keyboard_memory mem[COMPUTER_COUNT];
 	uint32_t down[4];
 	uint32_t sw_seq;
+	void (*reg2_callback)(uint8_t, uint16_t);
 } keyboard;
 
 static volatile uint8_t active;
@@ -173,19 +170,6 @@ static void reg2_update(uint8_t code, uint16_t *reg2)
 		// down key
 		*reg2 &= ~mask;
 	}
-}
-
-/*
- * Sends a blind Listen Register 2 to the keyboard with the given handler ID,
- * updating the low 3 bits of Register 2 with new LED information.
- */
-static void send_host_reg2(uint8_t hdev, uint16_t reg2)
-{
-	uint32_t id;
-	uint8_t send[2];
-	send[0] = (reg2 >> 8) & 0xFF;
-	send[1] = reg2 & 0xFF;
-	host_cmd(hdev, COMMAND_LISTEN_2, &id, send, 2);
 }
 
 /*
@@ -287,7 +271,9 @@ static void drvr_reset(uint8_t comp, uint32_t ref)
 		// physical keyboard's current pressed keys
 		send_down_keys(ref, comp);
 		// update keyboard LEDs accordingly (TODO eval how well this is done)
-		send_host_reg2(keyboards[ref].hdev, keyboards[ref].mem[comp].reg2);
+		if (keyboards[ref].reg2_callback) {
+			keyboards[ref].reg2_callback(ref, keyboards[ref].mem[comp].reg2);
+		}
 	}
 
 	set_comp_reg2(comp, keyboards[ref].drv_idx, keyboards[ref].mem[comp].reg2);
@@ -298,7 +284,9 @@ static void drvr_switch(uint8_t comp)
 	for (uint8_t i = 0; i < keyboard_count; i++) {
 		computer_psw(active, false);
 		keyboards[i].sw_seq = 0;
-		send_host_reg2(keyboards[i].hdev, keyboards[i].mem[comp].reg2);
+		if (keyboards[i].reg2_callback) {
+			keyboards[i].reg2_callback(i, keyboards[i].mem[comp].reg2);
+		}
 	}
 	active = comp;
 }
@@ -314,8 +302,8 @@ static void drvr_listen(uint8_t comp, uint32_t ref, uint8_t reg,
 		*reg2 = (*reg2 & 0xFFF8) | leds;
 
 		// if it is the active computer, update now
-		if (comp == active) {
-			send_host_reg2(keyboards[ref].hdev, *reg2);
+		if (comp == active && keyboards[ref].reg2_callback) {
+			keyboards[ref].reg2_callback(ref, *reg2);
 		}
 	}
 }
@@ -342,115 +330,64 @@ static dev_driver keyboard_driver = {
 	.set_handle_func = drvr_set_handle
 };
 
-/*
- * ----------------------------------------------------------------------------
- * --- Handler for Real ADB Keyboards -----------------------------------------
- * ----------------------------------------------------------------------------
- */
-
-static bool hndl_interview(volatile ndev_info *info, bool (*handle_change)(uint8_t, bool))
-{
-	if (keyboard_count >= MAX_KEYBOARDS) return false;
-	if (info->address_def != 0x02) return false;
-//	if (! (info->dhid_cur >= 0x01 && info->dhid_cur <= 0x03)) return false;
-
-	dbg("    kdb assoc to %d at $%X", info->hdev, info->address_cur);
-	keyboard *kbd = &keyboards[keyboard_count];
-	kbd->hdev = info->hdev;
-	kbd->extended = handle_change(0x03, true);
-
-	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
-		if (kbd->extended) {
-			kbd->mem[c].dhi = 0x03;
-		} else {
-			kbd->mem[c].dhi = 0x02;
-		}
-		kbd->mem[c].queue = xQueueCreate(KEYBOARD_QUEUE_DEPTH,
-				sizeof(keyboard_message));
-		assert(kbd->mem[c].queue != NULL);
-		kbd->mem[c].reg2 = DEFAULT_REGISTER_2;
-	}
-
-	driver_register(&kbd->drv_idx, &keyboard_driver, keyboard_count);
-	keyboard_count++;
-	return true;
-}
-
-static void hndl_talk(uint8_t hdev, host_err err, uint32_t cid, uint8_t reg,
-		uint8_t *data, uint8_t data_len)
+void keyboard_enqueue(uint8_t id, keyboard_message *m)
 {
 	if (active >= COMPUTER_COUNT) return;
+	if (id >= keyboard_count) return;
 
-	uint8_t i;
-	for (i = 0; i < keyboard_count; i++) {
-		if (keyboards[i].hdev == hdev) break;
+	uint8_t hi = m->data[1];
+	uint8_t lo = m->data[0];
+
+	// handle power switch activation
+	if (lo == 0x7F && hi == 0x7F) {
+		computer_psw(active, true);
+	} else if (lo == 0xFF && hi == 0xFF) {
+		computer_psw(active, false);
 	}
-	if (i == keyboard_count) return;
 
-	if (data_len >= 2 && active < COMPUTER_COUNT) {
-		dbg("kbd: %d %d", data[0], data[1]);
-
-		// handle power switch activation
-		if (data[0] == 0x7F && data[1] == 0x7F) {
-			computer_psw(active, true);
-		} else if (data[0] == 0xFF && data[1] == 0xFF) {
-			computer_psw(active, false);
+	// handle switching
+	// hi==lo seems to happen sometimes on meta key up
+	if (hi == 0xFF || lo == hi) {
+		if (lo > 0x80) {
+			keyboards[id].sw_seq <<= 8;
+			keyboards[id].sw_seq += lo;
+		} else if (keyboards[id].sw_seq == SWITCH_SEQUENCE
+				&& lo >= ONE_KEY_DOWN
+				&& lo < ONE_KEY_DOWN + sizeof(codes_to_comp_idx)) {
+			// match, veto keystroke and switch instead
+			computer_switch(codes_to_comp_idx[lo - ONE_KEY_DOWN], true);
+			return;
 		}
-
-		// handle switching
-		// hi==lo seems to happen sometimes on meta key up
-		if (data[1] == 0xFF || data[0] == data[1]) {
-			if (data[0] > 0x80) {
-				keyboards[i].sw_seq <<= 8;
-				keyboards[i].sw_seq += data[0];
-			} else if (keyboards[i].sw_seq == SWITCH_SEQUENCE
-					&& data[0] >= ONE_KEY_DOWN
-					&& data[0] < ONE_KEY_DOWN + sizeof(codes_to_comp_idx)) {
-				// match, veto keystroke and switch instead
-				computer_switch(codes_to_comp_idx[data[0] - ONE_KEY_DOWN], true);
-				return;
-			}
-		} else {
-			keyboards[i].sw_seq = 0;
-		}
-
-		// set appropriate bits in Register 2 based on key state
-		// along with the map of keys pressed
-		uint16_t old_reg2 = keyboards[i].mem[active].reg2;
-		if (data[0] != 0xFF) {
-			reg2_update(data[0], &keyboards[i].mem[active].reg2);
-			down_update(data[0], keyboards[i].down);
-		}
-		if (data[1] != 0xFF) {
-			reg2_update(data[1], &keyboards[i].mem[active].reg2);
-			down_update(data[1], keyboards[i].down);
-		}
-
-		// update the real register if needed
-		if (old_reg2 != keyboards[i].mem[active].reg2) {
-			set_comp_reg2(active, keyboards[i].drv_idx,
-					keyboards[i].mem[active].reg2);
-		}
-
-		// enqueue data, dropping if queue is full
-		keyboard_message kb;
-		kb.length = 2;
-		kb.data[0] = data[0];
-		kb.data[1] = data[1];
-		xQueueSend(keyboards[i].mem[active].queue, &kb, 0);
+	} else {
+		keyboards[id].sw_seq = 0;
 	}
+
+	// set appropriate bits in Register 2 based on key state
+	// along with the map of keys pressed
+	uint16_t old_reg2 = keyboards[id].mem[active].reg2;
+	if (lo != 0xFF) {
+		reg2_update(lo, &keyboards[id].mem[active].reg2);
+		down_update(lo, keyboards[id].down);
+	}
+	if (hi != 0xFF) {
+		reg2_update(hi, &keyboards[id].mem[active].reg2);
+		down_update(hi, keyboards[id].down);
+	}
+
+	// update the real register if needed
+	if (old_reg2 != keyboards[id].mem[active].reg2) {
+		set_comp_reg2(active, keyboards[id].drv_idx,
+				keyboards[id].mem[active].reg2);
+	}
+
+	// enqueue data, dropping if queue is full
+	xQueueSend(keyboards[id].mem[active].queue, m, 0);
 }
 
-static ndev_handler keyboard_handler = {
-	.name = "kbd",
-	.accept_noop_talks = false,
-	.interview_func = hndl_interview,
-	.talk_func = hndl_talk,
-	.listen_func = NULL,
-	.flush_func = NULL,
-};
-
-void keyboard_init(void)
+bool keyboard_register(uint8_t *id, void (*reg2_callback)(uint8_t, uint16_t))
 {
-	handler_register(&keyboard_handler);
+	if (keyboard_count >= MAX_KEYBOARDS) return false;
+	keyboards[keyboard_count].reg2_callback = reg2_callback;
+	*id = keyboard_count++;
+	return driver_register(&(keyboards[*id].drv_idx), &keyboard_driver, *id);
 }

--- a/firmware/drivers/keyboard.h
+++ b/firmware/drivers/keyboard.h
@@ -18,6 +18,30 @@
 #ifndef __KEYBOARD_H__
 #define __KEYBOARD_H__
 
-void keyboard_init(void);
+typedef struct {
+	uint8_t length;
+	uint8_t data[2];
+} keyboard_message;
+
+/**
+ * Enqueues a message to send to the active computer at the next opportunity.
+ *
+ * @param id  the ID to use from the original registration call.
+ * @param m   the message to enqueue.
+ */
+void keyboard_enqueue(uint8_t id, keyboard_message *m);
+
+/**
+ * Registers a computer-facing keyboard and assigns it for exclusive use to
+ * the caller.
+ *
+ * @param *id            on success, set to the ID that should be used during
+ *                       enqueue operations.
+ * @param reg2_callback  function called at appropriate times to update
+ *                       register 2; this may be null and each user may choose
+ *                       how to respect this call (or not).
+ * @return               true if registration was successful, false otherwise.
+ */
+bool keyboard_register(uint8_t *id, void (*reg2_callback)(uint8_t, uint16_t));
 
 #endif /* __KEYBOARD_H__ */

--- a/firmware/drivers/keyboard_handler.c
+++ b/firmware/drivers/keyboard_handler.c
@@ -96,7 +96,7 @@ static void hndl_talk(uint8_t hdev, host_err err, uint32_t cid, uint8_t reg,
 	if (i == keyboard_count) return;
 
 	if (data_len >= 2) {
-		dbg("kbd: %d %d", data[0], data[1]);
+		dbg("kbd_h: %d %d", data[0], data[1]);
 
 		// enqueue data, dropping if queue is full
 		keyboard_message kb;

--- a/firmware/drivers/keyboard_handler.c
+++ b/firmware/drivers/keyboard_handler.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2024-2026 saybur
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "pico/stdlib.h"
+
+#include "debug.h"
+#include "handler.h"
+#include "hardware.h"
+#include "host.h"
+#include "host_err.h"
+
+#include "keyboard.h"
+#include "keyboard_handler.h"
+
+/*
+ * Handler (real ADB device) implementation for keyboards following the
+ * standard keyboard protocol.
+ */
+
+// sets the most number of passthru keyboards permitted
+#define MAX_KEYBOARDS 3
+
+typedef struct {
+	uint8_t hdev;
+	uint8_t idx;
+	bool extended;
+} keyboard;
+
+static keyboard keyboards[MAX_KEYBOARDS];
+static uint8_t keyboard_count;
+
+/*
+ * ----------------------------------------------------------------------------
+ * --- Utility Functions ------------------------------------------------------
+ * ----------------------------------------------------------------------------
+ */
+
+/*
+ * Sends a blind Listen Register 2 to the keyboard with the given handler ID,
+ * updating the low 3 bits of Register 2 with new LED information.
+ */
+static void send_host_reg2(uint8_t idx, uint16_t reg2)
+{
+	uint32_t id;
+	uint8_t send[2];
+	send[0] = (reg2 >> 8) & 0xFF;
+	send[1] = reg2 & 0xFF;
+	host_cmd(keyboards[idx].hdev, COMMAND_LISTEN_2, &id, send, 2);
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * --- Handler for Real ADB Keyboards -----------------------------------------
+ * ----------------------------------------------------------------------------
+ */
+
+static bool hndl_interview(volatile ndev_info *info, bool (*handle_change)(uint8_t, bool))
+{
+	if (keyboard_count >= MAX_KEYBOARDS) return false;
+	if (info->address_def != 0x02) return false;
+
+	dbg("    kdb assoc to %d at $%X", info->hdev, info->address_cur);
+	keyboard *kbd = &keyboards[keyboard_count];
+	kbd->hdev = info->hdev;
+	kbd->extended = handle_change(0x03, true);
+
+	if (keyboard_register(&kbd->idx, send_host_reg2)) {
+		keyboard_count++;
+		return true;
+	} else {
+		return true;
+	}
+}
+
+static void hndl_talk(uint8_t hdev, host_err err, uint32_t cid, uint8_t reg,
+		uint8_t *data, uint8_t data_len)
+{
+	uint8_t i;
+	for (i = 0; i < keyboard_count; i++) {
+		if (keyboards[i].hdev == hdev) break;
+	}
+	if (i == keyboard_count) return;
+
+	if (data_len >= 2) {
+		dbg("kbd: %d %d", data[0], data[1]);
+
+		// enqueue data, dropping if queue is full
+		keyboard_message kb;
+		kb.length = 2;
+		kb.data[0] = data[0];
+		kb.data[1] = data[1];
+		keyboard_enqueue(keyboards[i].idx, &kb);
+	}
+}
+
+static ndev_handler keyboard_handler = {
+	.name = "kbd",
+	.accept_noop_talks = false,
+	.interview_func = hndl_interview,
+	.talk_func = hndl_talk,
+	.listen_func = NULL,
+	.flush_func = NULL,
+};
+
+void keyboard_handler_init(void)
+{
+	handler_register(&keyboard_handler);
+}

--- a/firmware/drivers/keyboard_handler.h
+++ b/firmware/drivers/keyboard_handler.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024-2026 saybur
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef __KEYBOARD_HANDLER_H__
+#define __KEYBOARD_HANDLER_H__
+
+void keyboard_handler_init(void);
+
+#endif /* __KEYBOARD_HANDLER_H__ */

--- a/firmware/drivers/mouse.c
+++ b/firmware/drivers/mouse.c
@@ -45,6 +45,7 @@
 
 #define DEFAULT_ADDRESS 3
 #define DEFAULT_HANDLER 1
+#define EXTENDED_HANDLER 4
 #define MAX_MICE 4
 
 typedef struct {
@@ -91,7 +92,7 @@ static void drvr_get_handle(uint8_t comp, uint32_t ref, uint8_t *hndl)
 
 static void drvr_set_handle(uint8_t comp, uint32_t ref, uint8_t hndl)
 {
-	if (hndl == 0x04 && mice[ref].extended_ok) {
+	if (hndl == EXTENDED_HANDLER && mice[ref].extended_ok) {
 		mice[ref].dhi[comp] = hndl;
 	}
 	if (hndl == 0x01 || hndl == 0x02) {
@@ -103,21 +104,20 @@ static void drvr_talk(uint8_t comp, uint32_t ref, uint8_t reg)
 {
 	if (active != comp) return;
 
-	if (reg == 0x00 && xSemaphoreTake(mice[ref].sem, portMAX_DELAY)) {
-		if (mice[ref].pending) {
+	mouse *mse = &mice[ref];
+
+	if (reg == 0x00 && xSemaphoreTake(mse->sem, portMAX_DELAY)) {
+		if (mse->pending) {
 			uint8_t data[5];
-			util_mouse_encode(data,
-					mice[ref].x,
-					mice[ref].y,
-					mice[ref].buttons);
-			uint8_t len = (mice[ref].dhi[comp] == 0x04 ? 5 : 2);
-			if (computer_data_offer(active, mice[ref].drv_idx, 0, data, len)) {
-				mice[ref].pending = false;
-				mice[ref].x = 0;
-				mice[ref].y = 0;
+			util_mouse_encode(data, mse->x, mse->y, mse->buttons);
+			uint8_t len = (mse->dhi[comp] == EXTENDED_HANDLER ? 5 : 2);
+			if (computer_data_offer(active, mse->drv_idx, 0, data, len)) {
+				mse->pending = false;
+				mse->x = 0;
+				mse->y = 0;
 			}
 		}
-		xSemaphoreGive(mice[ref].sem);
+		xSemaphoreGive(mse->sem);
 	}
 }
 
@@ -137,13 +137,34 @@ bool mouse_update(uint8_t id, int16_t dx, int16_t dy, uint8_t btn)
 	if (active >= COMPUTER_COUNT) return false;
 	if (id >= mouse_count) return false;
 
-	if (xSemaphoreTake(mice[id].sem, portMAX_DELAY)) {
-		mice[id].x += dx;
-		mice[id].y += dy;
-		mice[id].buttons = btn;
-		xSemaphoreGive(mice[id].sem);
+	dbg("mse: x:%d, y:%d, btn:0x%02X", dx, dy, btn);
+
+	mouse *mse = &mice[id];
+
+	if (xSemaphoreTake(mse->sem, portMAX_DELAY)) {
+		mse->x += dx;
+		mse->y += dy;
+		mse->buttons = btn;
+
+		// encode the resulting output
+		uint8_t data_out[5];
+		util_mouse_encode(data_out, mse->x, mse->y, mse->buttons);
+		uint8_t data_out_len = mse->dhi[active] == EXTENDED_HANDLER ? 5 : 2;
+
+		// try to send data, or if send can't be done, store
+		if (computer_data_offer(active, mse->drv_idx, 0,
+				data_out, data_out_len)) {
+			mse->pending = false;
+			mse->x = 0;
+			mse->y = 0;
+		} else {
+			mse->pending = true;
+		}
+
+		xSemaphoreGive(mse->sem);
 		return true;
 	} else {
+		dbg("mse: drop rpt!");
 		return false;
 	}
 }
@@ -153,22 +174,23 @@ bool mouse_register(uint8_t *id, uint8_t *reg1)
 	if (mouse_count >= MAX_MICE) return false;
 
 	*id = mouse_count++;
+	mouse *mse = &mice[*id];
 
-	mice[*id].sem = xSemaphoreCreateMutex();
+	mse->sem = xSemaphoreCreateMutex();
 	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
-		mice[*id].dhi[c] = DEFAULT_HANDLER;
+		mse->dhi[c] = DEFAULT_HANDLER;
 	}
-	assert(mice[*id].sem != NULL);
-	mice[*id].buttons = 0xFF;
+	assert(mse->sem != NULL);
+	mse->buttons = 0xFF;
 
-	if (! driver_register(&(mice[*id].drv_idx), &mouse_driver, *id)) {
+	if (! driver_register(&mse->drv_idx, &mouse_driver, *id)) {
 		return false;
 	}
 
 	if (reg1) {
-		mice[*id].extended_ok = true;
+		mse->extended_ok = true;
 		for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
-			computer_data_set(c, mice[*id].drv_idx, 1, reg1, 8, true);
+			computer_data_set(c, mse->drv_idx, 1, reg1, 8, true);
 		}
 	}
 }

--- a/firmware/drivers/mouse.c
+++ b/firmware/drivers/mouse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 saybur
+ * Copyright (C) 2024-2026 saybur
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,41 +25,36 @@
 #include "computer.h"
 #include "debug.h"
 #include "driver.h"
-#include "handler.h"
 #include "hardware.h"
-#include "host.h"
-#include "host_err.h"
-#include "host_sync.h"
 #include "util.h"
 
 #include "mouse.h"
 
 /*
- * Mouse driver for ADB relative motion devices following either the standard
- * (0x01/0x02) or extended (0x04) mouse protocols. See Technote HW01 (Space
- * Aliens Ate My Mouse) for protocol details and reference materials.
+ * Driver (computer-side) for ADB relative motion devices following either the
+ * standard (0x01/0x02) or extended (0x04) mouse protocols. See Technote HW01
+ * (Space Aliens Ate My Mouse) for protocol details and reference materials.
  *
  * The "classic" protocol uses handlers 0x01 (100cpi) or 0x02 (200cpi). For
  * simplicity only the former is used: if a computer switches the mouse to
  * 200cpi the data from a non-extended mouse is simply scaled when responding.
+ *
+ * TODO this implementation needs the 100/200 cpi stuff evaluated, I don't
+ * think it is right.
  */
 
 #define DEFAULT_ADDRESS 3
 #define DEFAULT_HANDLER 1
-
-// sets the most number of passthru mice permitted
 #define MAX_MICE 4
 
 typedef struct {
-	uint8_t hdev;
 	uint8_t drv_idx;
 	uint8_t dhi[COMPUTER_COUNT];
-	bool extended;     // true if hardware mouse is in extended (0x04) mode
 	SemaphoreHandle_t sem;
+	bool extended_ok;  // true if extended (0x04) DHID should be allowed
 	bool pending;      // true if motion cache is valid
 	int16_t x, y;      // accumulated X/Y movement data
 	uint8_t buttons;   // last seen button data, 0=pressed, 1=released
-	uint8_t reg1[8];   // register 1 data
 } mouse;
 
 static volatile uint8_t active = 255;
@@ -96,9 +91,10 @@ static void drvr_get_handle(uint8_t comp, uint32_t ref, uint8_t *hndl)
 
 static void drvr_set_handle(uint8_t comp, uint32_t ref, uint8_t hndl)
 {
-	if (hndl == 0x01
-			|| hndl == 0x02
-			|| hndl == 0x04) {
+	if (hndl == 0x04 && mice[ref].extended_ok) {
+		mice[ref].dhi[comp] = hndl;
+	}
+	if (hndl == 0x01 || hndl == 0x02) {
 		mice[ref].dhi[comp] = hndl;
 	}
 }
@@ -110,17 +106,18 @@ static void drvr_talk(uint8_t comp, uint32_t ref, uint8_t reg)
 	if (reg == 0x00 && xSemaphoreTake(mice[ref].sem, portMAX_DELAY)) {
 		if (mice[ref].pending) {
 			uint8_t data[5];
-			util_mouse_encode(data, mice[ref].x, mice[ref].y, mice[ref].buttons);
+			util_mouse_encode(data,
+					mice[ref].x,
+					mice[ref].y,
+					mice[ref].buttons);
 			uint8_t len = (mice[ref].dhi[comp] == 0x04 ? 5 : 2);
 			if (computer_data_offer(active, mice[ref].drv_idx, 0, data, len)) {
 				mice[ref].pending = false;
+				mice[ref].x = 0;
+				mice[ref].y = 0;
 			}
 		}
 		xSemaphoreGive(mice[ref].sem);
-
-	} else if (reg == 0x01 && mice[ref].dhi[comp] == 0x04) {
-		// register 1 only supported in extended mouse protocol
-		computer_data_offer(active, mice[ref].drv_idx, 0x01, mice[ref].reg1, 8);
 	}
 }
 
@@ -135,138 +132,43 @@ static dev_driver mouse_driver = {
 	.set_handle_func = NULL
 };
 
-/*
- * ----------------------------------------------------------------------------
- * --- Handler for Real ADB Mice ----------------------------------------------
- * ----------------------------------------------------------------------------
- */
+bool mouse_update(uint8_t id, int16_t dx, int16_t dy, uint8_t btn)
+{
+	if (active >= COMPUTER_COUNT) return false;
+	if (id >= mouse_count) return false;
 
-static bool hndl_interview(volatile ndev_info *info, bool (*handle_change)(uint8_t, bool))
+	if (xSemaphoreTake(mice[id].sem, portMAX_DELAY)) {
+		mice[id].x += dx;
+		mice[id].y += dy;
+		mice[id].buttons = btn;
+		xSemaphoreGive(mice[id].sem);
+		return true;
+	} else {
+		return false;
+	}
+}
+
+bool mouse_register(uint8_t *id, uint8_t *reg1)
 {
 	if (mouse_count >= MAX_MICE) return false;
-	if (info->address_def != DEFAULT_ADDRESS) return false;
 
-	// probe mouse for a general Talk 3 response
-	// if nothing returned it's likely a disabled Kensington secondary device
-	host_err err;
-	uint8_t dev_reg[8];
-	uint8_t dev_reg_len;
-	if (err = host_sync_cmd(info->hdev, COMMAND_TALK_3, dev_reg, &dev_reg_len)) {
-		dbg("    id %d t3 resp %d, skip", info->hdev, err);
+	*id = mouse_count++;
+
+	mice[*id].sem = xSemaphoreCreateMutex();
+	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
+		mice[*id].dhi[c] = DEFAULT_HANDLER;
+	}
+	assert(mice[*id].sem != NULL);
+	mice[*id].buttons = 0xFF;
+
+	if (! driver_register(&(mice[*id].drv_idx), &mouse_driver, *id)) {
 		return false;
 	}
 
-	// past this point we assume adoption unless it errors out
-	mouse *mse = &mice[mouse_count];
-	mse->hdev = info->hdev;
-	if (mse->sem == NULL) {
-		mse->sem = xSemaphoreCreateMutex();
-	}
-	assert(mse->sem != NULL);
-
-	// try to change the device to the extended mouse protocol
-	if (handle_change(0x04, true)) {
-		// read and store register 1
-		uint8_t dev_reg1[8];
-		uint8_t dev_reg1_len;
-		host_sync_cmd(info->hdev, COMMAND_TALK_1, dev_reg1, &dev_reg1_len);
-		if (dev_reg1_len == 8) {
-			// store register 1 information
-			memcpy(mse->reg1, dev_reg1, 8);
-			mse->extended = true;
-		} else {
-			// not valid extended response, reset to original handler
-			dbg_err("mse: dev %d dhid 4 bad reg1", info->hdev);
-			handle_change(info->dhid_def, true);
+	if (reg1) {
+		mice[*id].extended_ok = true;
+		for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
+			computer_data_set(c, mice[*id].drv_idx, 1, reg1, 8, true);
 		}
-	}
-
-	// make sure device is in a valid mode
-	if (! (info->dhid_cur == 0x01 || info->dhid_cur == 0x04)) {
-		// already tried extended, move to basic protocol
-		if (! handle_change(0x01, true)) {
-			// failed to accept, must not be a mouse?
-			dbg_err("mse: dev %d reject dhid 1, dropped", info->hdev);
-			return false;
-		}
-	}
-
-	// for emulation, start at device handler 1 until changed
-	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
-		mse->dhi[c] = DEFAULT_HANDLER;
-	}
-
-	driver_register(&mse->drv_idx, &mouse_driver, mouse_count);
-	mouse_count++;
-	return true;
-}
-
-static void hndl_talk(uint8_t hdev, host_err err, uint32_t cid, uint8_t reg,
-		uint8_t *data, uint8_t data_len)
-{
-	// ignore until there is a computer to send data to
-	if (active >= COMPUTER_COUNT) return;
-
-	// select the correct device mapping
-	uint8_t i;
-	for (i = 0; i < mouse_count; i++) {
-		if (mice[i].hdev == hdev) break;
-	}
-	if (i == mouse_count) return;
-
-	if (reg == 0 && data_len >= 2) {
-		// decode incoming data from the mouse
-		int16_t xt, yt;
-		uint8_t buttons;
-		util_mouse_decode(data, data_len, &xt, &yt, &buttons);
-
-		if (xSemaphoreTake(mice[i].sem, portMAX_DELAY)) {
-			// include any pending motion data
-			if (mice[i].pending) {
-				xt += mice[i].x;
-				yt += mice[i].y;
-			}
-
-			// encode the resulting output
-			uint8_t data_out[5];
-			util_mouse_encode(data_out, xt, yt, buttons);
-			uint8_t data_out_len = mice[i].extended ? 5 : 2;
-
-			// try to send data, or if send can't be done, store
-			if (computer_data_offer(active, mice[i].drv_idx, 0,
-					data_out, data_out_len)) {
-				mice[i].pending = false;
-			} else {
-				mice[i].pending = true;
-				mice[i].x = xt;
-				mice[i].y = yt;
-				mice[i].buttons = buttons;
-			}
-			xSemaphoreGive(mice[i].sem);
-		}
-
-		dbg("mse: %d %d", data[0], data[1]);
-	}
-}
-
-static ndev_handler mouse_handler = {
-	.name = "mse",
-	.accept_noop_talks = false,
-	.interview_func = hndl_interview,
-	.talk_func = hndl_talk,
-	.listen_func = NULL,
-	.flush_func = NULL
-};
-
-void mouse_init(void)
-{
-	handler_register(&mouse_handler);
-
-	// by default register 1 reports as ADB Mouse II
-	static const uint8_t default_reg1[8] =
-		{0x40, 0x32, 0x30, 0x30, 0x00, 0xC8, 0x01, 0x01};
-	for (uint8_t i = 0; i < MAX_MICE; i++) {
-		mice[i].buttons = 0xFF;
-		memcpy(mice[i].reg1, default_reg1, sizeof(default_reg1));
 	}
 }

--- a/firmware/drivers/mouse.c
+++ b/firmware/drivers/mouse.c
@@ -44,18 +44,22 @@
  */
 
 #define DEFAULT_ADDRESS 3
-#define DEFAULT_HANDLER 1
-#define EXTENDED_HANDLER 4
 #define MAX_MICE 4
 
 typedef struct {
 	uint8_t drv_idx;
 	uint8_t dhi[COMPUTER_COUNT];
 	SemaphoreHandle_t sem;
-	bool extended_ok;  // true if extended (0x04) DHID should be allowed
-	bool pending;      // true if motion cache is valid
-	int16_t x, y;      // accumulated X/Y movement data
-	uint8_t buttons;   // last seen button data, 0=pressed, 1=released
+	mouse_mode mode;
+	/*
+	 * An internal representation for the number of right-shifts required to
+	 * get the input data from its nominal CPI down to 100cpi for extended mice
+	 * operating at DHID 1; this value is ignored if not in extended mode.
+	 */
+	uint8_t rshift;
+	bool pending; // true if motion cache is valid
+	int32_t x, y;
+	uint8_t buttons; // last seen button data, 0=pressed, 1=released
 } mouse;
 
 static volatile uint8_t active = 255;
@@ -68,9 +72,64 @@ static uint8_t mouse_count;
  * ----------------------------------------------------------------------------
  */
 
+/**
+ * Provides the amount of right-shifting needed to convert from the mouse
+ * update native motion format to the level the active computer is using.
+ */
+static uint8_t mouse_rshift(mouse *mse)
+{
+	if (active >= COMPUTER_COUNT) return 0;
+
+	if (mse->mode == MOUSE_MODE_EXTENDED
+			&& mse->dhi[active] != MOUSE_MODE_EXTENDED) {
+		return mse->rshift;
+	} else {
+		return 0;
+	}
+}
+
+/*
+ * Internal function for offering data to the active computer, either in
+ * response to a Talk or when new data has been sent into the system. This
+ * must be called only when valid data is present AND when the mouse semaphore
+ * is locked!
+ */
+static void mouse_offer(mouse *mse, uint8_t rshift)
+{
+	uint8_t data[5];
+	util_mouse_encode(data,
+			rshift,
+			mse->x,
+			mse->y,
+			mse->buttons);
+	uint8_t data_len = mse->dhi[active] == MOUSE_MODE_EXTENDED ? 5 : 2;
+
+	// try to send data, or if send can't be done, store
+	if (computer_data_offer(active, mse->drv_idx, 0,
+			data, data_len)) {
+		mse->pending = false;
+		mse->x = 0;
+		mse->y = 0;
+	} else {
+		mse->pending = true;
+	}
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * --- Computer-Side Mouse Driver ---------------------------------------------
+ * ----------------------------------------------------------------------------
+ */
+
 static void drvr_reset(uint8_t comp, uint32_t ref)
 {
-	mice[ref].dhi[comp] = DEFAULT_HANDLER;
+	if (mice[ref].mode == MOUSE_MODE_EXTENDED) {
+		// extended mice start at DHID 0x01 per HW01
+		mice[ref].dhi[comp] = MOUSE_MODE_100CPI;
+	} else {
+		// non-extended mice start at their default CPI
+		mice[ref].dhi[comp] = mice[ref].mode;
+	}
 
 	if (active == comp) {
 		if (xSemaphoreTake(mice[ref].sem, portMAX_DELAY)) {
@@ -92,11 +151,10 @@ static void drvr_get_handle(uint8_t comp, uint32_t ref, uint8_t *hndl)
 
 static void drvr_set_handle(uint8_t comp, uint32_t ref, uint8_t hndl)
 {
-	if (hndl == EXTENDED_HANDLER && mice[ref].extended_ok) {
-		mice[ref].dhi[comp] = hndl;
-	}
-	if (hndl == 0x01 || hndl == 0x02) {
-		mice[ref].dhi[comp] = hndl;
+	// only extended mice are willing to change their device handler ID
+	if (hndl == MOUSE_MODE_EXTENDED
+			&& mice[ref].mode == MOUSE_MODE_EXTENDED) {
+		mice[ref].dhi[comp] = MOUSE_MODE_EXTENDED;
 	}
 }
 
@@ -105,17 +163,11 @@ static void drvr_talk(uint8_t comp, uint32_t ref, uint8_t reg)
 	if (active != comp) return;
 
 	mouse *mse = &mice[ref];
+	uint8_t rshift = mouse_rshift(mse);
 
 	if (reg == 0x00 && xSemaphoreTake(mse->sem, portMAX_DELAY)) {
 		if (mse->pending) {
-			uint8_t data[5];
-			util_mouse_encode(data, mse->x, mse->y, mse->buttons);
-			uint8_t len = (mse->dhi[comp] == EXTENDED_HANDLER ? 5 : 2);
-			if (computer_data_offer(active, mse->drv_idx, 0, data, len)) {
-				mse->pending = false;
-				mse->x = 0;
-				mse->y = 0;
-			}
+			mouse_offer(mse, rshift);
 		}
 		xSemaphoreGive(mse->sem);
 	}
@@ -132,34 +184,23 @@ static dev_driver mouse_driver = {
 	.set_handle_func = NULL
 };
 
-bool mouse_update(uint8_t id, int16_t dx, int16_t dy, uint8_t btn)
+bool mouse_update(uint8_t id, int32_t dx, int32_t dy, uint8_t btn)
 {
 	if (active >= COMPUTER_COUNT) return false;
 	if (id >= mouse_count) return false;
 
-	dbg("mse: x:%d, y:%d, btn:0x%02X", dx, dy, btn);
-
 	mouse *mse = &mice[id];
+	uint8_t rshift = mouse_rshift(mse);
+	dbg("mse: x:%d, y:%d, btn:0x%02X, rs:%d", dx, dy, btn, rshift);
 
 	if (xSemaphoreTake(mse->sem, portMAX_DELAY)) {
+		// with data locked, update with new values
 		mse->x += dx;
 		mse->y += dy;
 		mse->buttons = btn;
 
-		// encode the resulting output
-		uint8_t data_out[5];
-		util_mouse_encode(data_out, mse->x, mse->y, mse->buttons);
-		uint8_t data_out_len = mse->dhi[active] == EXTENDED_HANDLER ? 5 : 2;
-
-		// try to send data, or if send can't be done, store
-		if (computer_data_offer(active, mse->drv_idx, 0,
-				data_out, data_out_len)) {
-			mse->pending = false;
-			mse->x = 0;
-			mse->y = 0;
-		} else {
-			mse->pending = true;
-		}
+		// send data if possible
+		mouse_offer(mse, rshift);
 
 		xSemaphoreGive(mse->sem);
 		return true;
@@ -169,7 +210,7 @@ bool mouse_update(uint8_t id, int16_t dx, int16_t dy, uint8_t btn)
 	}
 }
 
-bool mouse_register(uint8_t *id, uint8_t *reg1)
+bool mouse_register(uint8_t *id, mouse_mode mode, uint8_t *reg1)
 {
 	if (mouse_count >= MAX_MICE) return false;
 
@@ -177,20 +218,50 @@ bool mouse_register(uint8_t *id, uint8_t *reg1)
 	mouse *mse = &mice[*id];
 
 	mse->sem = xSemaphoreCreateMutex();
-	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
-		mse->dhi[c] = DEFAULT_HANDLER;
-	}
 	assert(mse->sem != NULL);
+	mse->mode = mode;
+	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
+		if (mode == MOUSE_MODE_EXTENDED) {
+			mse->dhi[c] = MOUSE_MODE_100CPI;
+		} else {
+			mse->dhi[c] = mode;
+		}
+	}
 	mse->buttons = 0xFF;
 
 	if (! driver_register(&mse->drv_idx, &mouse_driver, *id)) {
 		return false;
 	}
 
-	if (reg1) {
-		mse->extended_ok = true;
-		for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
-			computer_data_set(c, mse->drv_idx, 1, reg1, 8, true);
+	if (mode == MOUSE_MODE_EXTENDED) {
+		if (reg1) {
+			// pick a right-shift value approximately correct for adjusting
+			// true CPI down to the 100cpi used when not in extended mode
+			uint16_t cpi = (reg1[4] << 8) + reg1[5];
+			if (cpi > 9600) {
+				mse->rshift = 7;
+			} else if (cpi > 4800) {
+				mse->rshift = 6;
+			} else if (cpi > 2400) {
+				mse->rshift = 5;
+			} else if (cpi > 1200) {
+				mse->rshift = 4;
+			} else if (cpi > 600) {
+				mse->rshift = 3;
+			} else if (cpi > 300) {
+				mse->rshift = 2;
+			} else if (cpi > 150) {
+				mse->rshift = 1;
+			} else {
+				mse->rshift = 0;
+			}
+
+			for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
+				computer_data_set(c, mse->drv_idx, 1, reg1, 8, true);
+			}
+		} else {
+			// no reg1, revert to basic mode per contract
+			mse->mode = MOUSE_MODE_100CPI;
 		}
 	}
 }

--- a/firmware/drivers/mouse.h
+++ b/firmware/drivers/mouse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 saybur
+ * Copyright (C) 2024-2026 saybur
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,27 @@
 #ifndef __MOUSE_H__
 #define __MOUSE_H__
 
-void mouse_init(void);
+/**
+ * Registers a computer-facing mouse and assigns it for exclusive use to the
+ * caller.
+ *
+ * @param *id            on success, set to the ID that should be used during
+ *                       enqueue operations.
+ * @param *reg1          array of 8 bytes for extended mouse support, NULL if
+ *                       not desired (if NULL will block extended support).
+ * @return               true if registration was successful, false otherwise.
+ */
+bool mouse_register(uint8_t *id, uint8_t *reg1);
+
+/**
+ * Updates the mouse position information, appending it to any existing data.
+ * This locks an internal semaphore and may block when called.
+ *
+ * @param id   the ID to use from the original registration call.
+ * @param dx   change in X-axis position.
+ * @param dy   change in Y-axis position.
+ * @param btn  button state bitmask following ADB convention: 0=down, LSB b1
+ */
+bool mouse_update(uint8_t id, int16_t dx, int16_t dy, uint8_t btn);
 
 #endif /* __MOUSE_H__ */

--- a/firmware/drivers/mouse.h
+++ b/firmware/drivers/mouse.h
@@ -18,27 +18,44 @@
 #ifndef __MOUSE_H__
 #define __MOUSE_H__
 
+typedef enum {
+	MOUSE_MODE_100CPI = 1,
+	MOUSE_MODE_200CPI = 2,
+	MOUSE_MODE_EXTENDED = 4
+} mouse_mode;
+
 /**
  * Registers a computer-facing mouse and assigns it for exclusive use to the
- * caller.
+ * caller. If provided, register 1 contents are checked to determine how
+ * _update() should treat motion data submitted later (bytes 4-5).
+ *
+ * _Note_: to avoid expensive division the scaling implementation here is
+ * tailored to work with devices that are some power of 2 multipled by 100.
+ * Using other CPI values will cause inaccuracy.
  *
  * @param *id            on success, set to the ID that should be used during
  *                       enqueue operations.
- * @param *reg1          array of 8 bytes for extended mouse support, NULL if
- *                       not desired (if NULL will block extended support).
+ * @param mode           the starting mouse mode to use.
+ * @param *reg1          array of 8 bytes for MOUSE_MODE_EXTENDED, otherwise
+ *                       otherwise; providing NULL when mode is extended drops
+ *                       the device to MOUSE_MODE_100CPI.
  * @return               true if registration was successful, false otherwise.
  */
-bool mouse_register(uint8_t *id, uint8_t *reg1);
+bool mouse_register(uint8_t *id, mouse_mode mode, uint8_t *reg1);
 
 /**
  * Updates the mouse position information, appending it to any existing data.
  * This locks an internal semaphore and may block when called.
+ *
+ * Callers should provide motion data scaled to the native CPI of their
+ * device. This will internally handle scaling based on both the current
+ * DHID/extended state with the computer(s).
  *
  * @param id   the ID to use from the original registration call.
  * @param dx   change in X-axis position.
  * @param dy   change in Y-axis position.
  * @param btn  button state bitmask following ADB convention: 0=down, LSB b1
  */
-bool mouse_update(uint8_t id, int16_t dx, int16_t dy, uint8_t btn);
+bool mouse_update(uint8_t id, int32_t dx, int32_t dy, uint8_t btn);
 
 #endif /* __MOUSE_H__ */

--- a/firmware/drivers/mouse_handler.c
+++ b/firmware/drivers/mouse_handler.c
@@ -52,8 +52,7 @@
 typedef struct {
 	uint8_t hdev;
 	uint8_t idx;
-	uint8_t dhi[COMPUTER_COUNT];
-	bool extended;     // true if hardware mouse is in extended (0x04) mode
+	mouse_mode mode;
 } mouse;
 
 static mouse mice[MAX_MICE];
@@ -86,42 +85,33 @@ static bool hndl_interview(volatile ndev_info *info, bool (*handle_change)(uint8
 
 	// try to change the device to the extended mouse protocol
 	uint8_t *reg1 = NULL;
-	if (handle_change(0x04, true)) {
+	if (handle_change(MOUSE_MODE_EXTENDED, true)) {
 		// read and store register 1
 		uint8_t dev_reg1[8];
 		uint8_t dev_reg1_len;
 		host_sync_cmd(info->hdev, COMMAND_TALK_1, dev_reg1, &dev_reg1_len);
 		if (dev_reg1_len == 8) {
 			reg1 = dev_reg1;
-			mse->extended = true;
+			mse->mode = MOUSE_MODE_EXTENDED;
 		} else {
-			// not valid extended response, reset to original handler
-			dbg_err("mse: dev %d dhid 4 bad reg1", info->hdev);
+			// not valid extended response, reset to original handler and
+			// drop the device, it likely (?) is not a standard mouse
+			dbg_err("mse: dev %d dhid 4 bad reg1, dropped", info->hdev);
 			handle_change(info->dhid_def, true);
-		}
-	}
-
-	// make sure device is in a valid mode
-	if (! (info->dhid_cur == 0x01
-			|| info->dhid_cur == 0x02
-			|| info->dhid_cur == 0x04)) {
-		// already tried extended, move to basic protocol
-		if (! handle_change(0x01, true)) {
-			// failed to accept, must not be a mouse?
-			dbg_err("mse: dev %d reject dhid 1, dropped", info->hdev);
 			return false;
 		}
-	}
-
-	// for emulation, start at device handler 1 until changed
-	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
-		mse->dhi[c] = DEFAULT_HANDLER;
+	} else if (handle_change(MOUSE_MODE_200CPI, true)) {
+		mse->mode = MOUSE_MODE_200CPI;
+	} else if (handle_change(MOUSE_MODE_100CPI, true)) {
+		mse->mode = MOUSE_MODE_100CPI;
+	} else {
+		dbg_err("mse: dev %d reject dhid 1, dropped", info->hdev);
+		return false;
 	}
 
 	// finally register with the mouse driver
-	mouse_register(&mse->idx, reg1);
+	mouse_register(&mse->idx, mse->mode, reg1);
 	mouse_count++;
-
 	return true;
 }
 

--- a/firmware/drivers/mouse_handler.c
+++ b/firmware/drivers/mouse_handler.c
@@ -102,7 +102,9 @@ static bool hndl_interview(volatile ndev_info *info, bool (*handle_change)(uint8
 	}
 
 	// make sure device is in a valid mode
-	if (! (info->dhid_cur == 0x01 || info->dhid_cur == 0x04)) {
+	if (! (info->dhid_cur == 0x01
+			|| info->dhid_cur == 0x02
+			|| info->dhid_cur == 0x04)) {
 		// already tried extended, move to basic protocol
 		if (! handle_change(0x01, true)) {
 			// failed to accept, must not be a mouse?
@@ -142,7 +144,7 @@ static void hndl_talk(uint8_t hdev, host_err err, uint32_t cid, uint8_t reg,
 		// then send it
 		mouse_update(mice[i].idx, xt, yt, buttons);
 
-		dbg("mse: %d %d", data[0], data[1]);
+		dbg("mse_h: %d %d", data[0], data[1]);
 	}
 }
 

--- a/firmware/drivers/mouse_handler.c
+++ b/firmware/drivers/mouse_handler.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2024-2026 saybur
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+#include "pico/stdlib.h"
+
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+#include "debug.h"
+#include "handler.h"
+#include "hardware.h"
+#include "host.h"
+#include "host_err.h"
+#include "host_sync.h"
+#include "util.h"
+
+#include "mouse.h"
+#include "mouse_handler.h"
+
+/*
+ * Mouse driver for ADB relative motion devices following either the standard
+ * (0x01/0x02) or extended (0x04) mouse protocols. See Technote HW01 (Space
+ * Aliens Ate My Mouse) for protocol details and reference materials.
+ *
+ * The "classic" protocol uses handlers 0x01 (100cpi) or 0x02 (200cpi). For
+ * simplicity only the former is used: if a computer switches the mouse to
+ * 200cpi the data from a non-extended mouse is simply scaled when responding.
+ */
+
+#define DEFAULT_ADDRESS 3
+#define DEFAULT_HANDLER 1
+
+// sets the most number of passthru mice permitted
+#define MAX_MICE 3
+
+typedef struct {
+	uint8_t hdev;
+	uint8_t idx;
+	uint8_t dhi[COMPUTER_COUNT];
+	bool extended;     // true if hardware mouse is in extended (0x04) mode
+} mouse;
+
+static mouse mice[MAX_MICE];
+static uint8_t mouse_count;
+
+/*
+ * ----------------------------------------------------------------------------
+ * --- Handler for Real ADB Mice ----------------------------------------------
+ * ----------------------------------------------------------------------------
+ */
+
+static bool hndl_interview(volatile ndev_info *info, bool (*handle_change)(uint8_t, bool))
+{
+	if (mouse_count >= MAX_MICE) return false;
+	if (info->address_def != DEFAULT_ADDRESS) return false;
+
+	// probe mouse for a general Talk 3 response
+	// if nothing returned it's likely a disabled Kensington secondary device
+	host_err err;
+	uint8_t dev_reg[8];
+	uint8_t dev_reg_len;
+	if (err = host_sync_cmd(info->hdev, COMMAND_TALK_3, dev_reg, &dev_reg_len)) {
+		dbg("    id %d t3 resp %d, skip", info->hdev, err);
+		return false;
+	}
+
+	// past this point we assume adoption unless it errors out
+	mouse *mse = &mice[mouse_count];
+	mse->hdev = info->hdev;
+
+	// try to change the device to the extended mouse protocol
+	uint8_t *reg1 = NULL;
+	if (handle_change(0x04, true)) {
+		// read and store register 1
+		uint8_t dev_reg1[8];
+		uint8_t dev_reg1_len;
+		host_sync_cmd(info->hdev, COMMAND_TALK_1, dev_reg1, &dev_reg1_len);
+		if (dev_reg1_len == 8) {
+			reg1 = dev_reg1;
+			mse->extended = true;
+		} else {
+			// not valid extended response, reset to original handler
+			dbg_err("mse: dev %d dhid 4 bad reg1", info->hdev);
+			handle_change(info->dhid_def, true);
+		}
+	}
+
+	// make sure device is in a valid mode
+	if (! (info->dhid_cur == 0x01 || info->dhid_cur == 0x04)) {
+		// already tried extended, move to basic protocol
+		if (! handle_change(0x01, true)) {
+			// failed to accept, must not be a mouse?
+			dbg_err("mse: dev %d reject dhid 1, dropped", info->hdev);
+			return false;
+		}
+	}
+
+	// for emulation, start at device handler 1 until changed
+	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
+		mse->dhi[c] = DEFAULT_HANDLER;
+	}
+
+	// finally register with the mouse driver
+	mouse_register(&mse->idx, reg1);
+	mouse_count++;
+
+	return true;
+}
+
+static void hndl_talk(uint8_t hdev, host_err err, uint32_t cid, uint8_t reg,
+		uint8_t *data, uint8_t data_len)
+{
+	// select the correct device mapping
+	uint8_t i;
+	for (i = 0; i < mouse_count; i++) {
+		if (mice[i].hdev == hdev) break;
+	}
+	if (i == mouse_count) return;
+
+	if (reg == 0 && data_len >= 2) {
+		// decode incoming data from the mouse
+		int16_t xt, yt;
+		uint8_t buttons;
+		util_mouse_decode(data, data_len, &xt, &yt, &buttons);
+
+		// then send it
+		mouse_update(mice[i].idx, xt, yt, buttons);
+
+		dbg("mse: %d %d", data[0], data[1]);
+	}
+}
+
+static ndev_handler mouse_handler = {
+	.name = "mse",
+	.accept_noop_talks = false,
+	.interview_func = hndl_interview,
+	.talk_func = hndl_talk,
+	.listen_func = NULL,
+	.flush_func = NULL
+};
+
+void mouse_handler_init(void)
+{
+	handler_register(&mouse_handler);
+}

--- a/firmware/drivers/mouse_handler.h
+++ b/firmware/drivers/mouse_handler.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024-2026 saybur
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef __MOUSE_HANDLER_H__
+#define __MOUSE_HANDLER_H__
+
+void mouse_handler_init(void);
+
+#endif /* __MOUSE_HANDLER_H__ */

--- a/firmware/drivers/serial.c
+++ b/firmware/drivers/serial.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 saybur
+ * Copyright (C) 2024-2026 saybur
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,10 @@
 #include "debug.h"
 #include "driver.h"
 #include "hardware.h"
+#include "util.h"
 
+#include "keyboard.h"
+#include "mouse.h"
 #include "serial.h"
 
 /*
@@ -40,128 +43,10 @@
  * list.
  */
 
-#define DEFAULT_MSE_HANDLER   1
-#define DEFAULT_KBD_HANDLER   2
-#define KEYBOARD_QUEUE_DEPTH  8
-
-typedef struct {
-	uint8_t length;
-	uint8_t data[2];
-} serial_message;
-
-typedef struct {
-	uint8_t drv_idx;
-	uint8_t dhi[COMPUTER_COUNT];
-	SemaphoreHandle_t sem;
-	bool pending;
-	uint8_t accum[2];
-	uint8_t cache[2];
-} serial_mouse;
-
-typedef struct {
-	uint8_t drv_idx;
-	QueueHandle_t queue;
-} serial_keyboard;
-
-static volatile uint8_t active = 255;
 static uint8_t command;
-static serial_mouse mouse;
-static serial_keyboard keyboard;
-
-/*
- * ----------------------------------------------------------------------------
- * --- Serial Driven Mouse Driver ---------------------------------------------
- * ----------------------------------------------------------------------------
- */
-
-static void drvr_mse_reset(uint8_t comp, uint32_t ref)
-{
-	mouse.dhi[comp] = DEFAULT_MSE_HANDLER;
-	if (active == comp) {
-		if (xSemaphoreTake(mouse.sem, portMAX_DELAY)) {
-			mouse.pending = false;
-			xSemaphoreGive(mouse.sem);
-		}
-	}
-}
-
-static void drvr_mse_switch(uint8_t comp)
-{
-	active = comp;
-}
-
-static void drvr_mse_get_handle(uint8_t comp, uint32_t ref, uint8_t *hndl)
-{
-	*hndl = mouse.dhi[comp];
-}
-
-static void drvr_mse_set_handle(uint8_t comp, uint32_t ref, uint8_t hndl)
-{
-	if (hndl != 1 || hndl != 2) return;
-	mouse.dhi[comp] = hndl;
-}
-
-static void drvr_mse_talk(uint8_t comp, uint32_t ref, uint8_t reg)
-{
-	if (active != comp || reg != 0) return;
-
-	if (xSemaphoreTake(mouse.sem, portMAX_DELAY)) {
-		if (mouse.pending) {
-			if (computer_data_offer(active, mouse.drv_idx, 0, mouse.accum, 2)) {
-				mouse.pending = false;
-			}
-		}
-		xSemaphoreGive(mouse.sem);
-	}
-}
-
-static dev_driver serial_mse_driver = {
-	.default_addr = 0x03,
-	.reset_func = drvr_mse_reset,
-	.switch_func = drvr_mse_switch,
-	.talk_func = drvr_mse_talk,
-	.listen_func = NULL,
-	.flush_func = NULL,
-	.get_handle_func = drvr_mse_get_handle,
-	.set_handle_func = drvr_mse_set_handle
-};
-
-/*
- * ----------------------------------------------------------------------------
- * --- Serial Driven Keyboard Driver ------------------------------------------
- * ----------------------------------------------------------------------------
- */
-
-static void drvr_kbd_reset(uint8_t comp, uint32_t ref)
-{
-	if (active == comp) {
-		xQueueReset(keyboard.queue);
-		computer_queue_set(comp, keyboard.drv_idx, keyboard.queue);
-	}
-}
-
-static void drvr_kbd_switch(uint8_t comp)
-{
-	computer_queue_set(active, keyboard.drv_idx, NULL);
-	computer_queue_set(comp, keyboard.drv_idx, keyboard.queue);
-	active = comp;
-}
-
-static void drvr_kbd_get_handle(uint8_t comp, uint32_t ref, uint8_t *hndl)
-{
-	*hndl = DEFAULT_KBD_HANDLER;
-}
-
-static dev_driver serial_kdb_driver = {
-	.default_addr = DEFAULT_KBD_HANDLER,
-	.reset_func = drvr_kbd_reset,
-	.switch_func = drvr_kbd_switch,
-	.talk_func = NULL,
-	.listen_func = NULL,
-	.flush_func = NULL,
-	.get_handle_func = drvr_kbd_get_handle,
-	.set_handle_func = NULL
-};
+static uint8_t kbd_idx;
+static uint8_t mse_idx;
+static uint8_t mse_cache[2];
 
 /*
  * ----------------------------------------------------------------------------
@@ -171,40 +56,19 @@ static dev_driver serial_kdb_driver = {
 
 static void serial_kbd_send(bool up, uint8_t c)
 {
-	serial_message msg;
+	keyboard_message msg;
 	msg.length = 2;
 	msg.data[0] = (up ? 0x80 : 0x00) | (c & 0x7F);
 	msg.data[1] = 0xFF;
-	if (c == 0x7F) {
-		msg.data[1] = msg.data[0];
-		computer_psw(active, !up);
-	}
-	xQueueSend(keyboard.queue, &msg, 0);
+	keyboard_enqueue(kbd_idx, &msg);
 }
 
 static void serial_mse_send()
 {
-	if (xSemaphoreTake(mouse.sem, portMAX_DELAY)) {
-		if (mouse.pending) {
-			// merge existing data with current data
-			mouse.cache[0] = (mouse.cache[0] & 0x80)
-					| ((mouse.cache[0] + mouse.accum[0]) & 0x7F);
-			mouse.cache[1] = (mouse.cache[1] & 0x80)
-					| ((mouse.cache[1] + mouse.accum[1]) & 0x7F);
-		}
-		// try to send data, or if send can't be done, store
-		if (computer_data_offer(active, mouse.drv_idx, 0, mouse.cache, 2)) {
-			mouse.pending = false;
-		} else {
-			mouse.pending = true;
-			mouse.accum[0] = mouse.cache[0];
-			mouse.accum[1] = mouse.cache[1];
-		}
-		xSemaphoreGive(mouse.sem);
-	}
-
-	mouse.cache[0] &= 0x80;
-	mouse.cache[1] &= 0x80;
+	int16_t x, y;
+	uint8_t btn;
+	util_mouse_decode(mse_cache, 2, &x, &y, &btn);
+	mouse_update(mse_idx, x, y, btn);
 }
 
 void serial_enqueue(uint8_t c) {
@@ -212,11 +76,11 @@ void serial_enqueue(uint8_t c) {
 		command = c;
 		switch (command) {
 		case SER_CMD_MSE_DOWN:
-			mouse.cache[0] &= ~0x80;
+			mse_cache[0] &= ~0x80;
 			serial_mse_send();
 			break;
 		case SER_CMD_MSE_UP:
-			mouse.cache[0] |= 0x80;
+			mse_cache[0] |= 0x80;
 			serial_mse_send();
 			break;
 		case SER_CMD_MSE_APPLY:
@@ -226,10 +90,10 @@ void serial_enqueue(uint8_t c) {
 	} else {
 		switch (command) {
 		case SER_CMD_MSE_X:
-			mouse.cache[1] = (mouse.cache[1] & 0x80) | c;
+			mse_cache[1] = (mse_cache[1] & 0x80) | c;
 			break;
 		case SER_CMD_MSE_Y:
-			mouse.cache[0] = (mouse.cache[0] & 0x80) | c;
+			mse_cache[0] = (mse_cache[0] & 0x80) | c;
 			break;
 		case SER_CMD_KBD_DOWN:
 			serial_kbd_send(false, c);
@@ -246,17 +110,6 @@ void serial_enqueue(uint8_t c) {
 
 void serial_init(void)
 {
-	mouse.sem = xSemaphoreCreateMutex();
-	for (uint8_t c = 0; c < COMPUTER_COUNT; c++) {
-		mouse.dhi[c] = DEFAULT_MSE_HANDLER;
-	}
-	assert(mouse.sem != NULL);
-	mouse.cache[0] = 0x80;
-	mouse.cache[1] = 0x80;
-
-	keyboard.queue = xQueueCreate(KEYBOARD_QUEUE_DEPTH,
-				sizeof(serial_message));
-
-	driver_register(&mouse.drv_idx, &serial_mse_driver, 1);
-	driver_register(&keyboard.drv_idx, &serial_kdb_driver, 1);
+	mouse_register(&mse_idx, MOUSE_MODE_100CPI, NULL);
+	keyboard_register(&kbd_idx, NULL);
 }

--- a/firmware/handler.c
+++ b/firmware/handler.c
@@ -23,7 +23,7 @@
 #include "drivers/joystick.h"
 #include "drivers/kensington.h"
 #include "drivers/keyboard_handler.h"
-#include "drivers/mouse.h"
+#include "drivers/mouse_handler.h"
 
 // the full list of possible device handlers
 static ndev_handler handler_list[HANDLER_MAX];
@@ -70,7 +70,7 @@ void handler_init(void)
 	 */
 
 	keyboard_handler_init();
-	mouse_init();
+	mouse_handler_init();
 	kensington_init();
 	joystick_init();
 }

--- a/firmware/handler.c
+++ b/firmware/handler.c
@@ -20,7 +20,7 @@
 #include "debug.h"
 #include "handler.h"
 
-#include "drivers/joystick.h"
+#include "drivers/joystick_handler.h"
 #include "drivers/kensington.h"
 #include "drivers/keyboard_handler.h"
 #include "drivers/mouse_handler.h"
@@ -72,5 +72,5 @@ void handler_init(void)
 	keyboard_handler_init();
 	mouse_handler_init();
 	kensington_init();
-	joystick_init();
+	joystick_handler_init();
 }

--- a/firmware/handler.c
+++ b/firmware/handler.c
@@ -22,7 +22,7 @@
 
 #include "drivers/joystick.h"
 #include "drivers/kensington.h"
-#include "drivers/keyboard.h"
+#include "drivers/keyboard_handler.h"
 #include "drivers/mouse.h"
 
 // the full list of possible device handlers
@@ -69,7 +69,7 @@ void handler_init(void)
 	 * ------------------------------------------------------------------------
 	 */
 
-	keyboard_init();
+	keyboard_handler_init();
 	mouse_init();
 	kensington_init();
 	joystick_init();

--- a/firmware/handler.h
+++ b/firmware/handler.h
@@ -78,6 +78,8 @@
  *   update with any new DHI value). Return true to take control of the device,
  *   false otherwise. If a malfunction occurs that should block further use of
  *   the device by other handlers set `fault` within the given struct.
+ *   _Note_: as part of this interview function, the flag for allowing SRQs is
+ *   sent; if that feature is desired provide _true_ for the bool parameter.
  * - talk_func is called whenever the device has returned data from a
  *   Talk Register command. If you set `accept_noop_talks` to true, this will
  *   be called with a length of 0 whenever a no-op talk occurs, which can be

--- a/firmware/util.c
+++ b/firmware/util.c
@@ -86,11 +86,18 @@ uint8_t util_mouse_decode(uint8_t* data, uint8_t data_len,
 	return 0;
 }
 
-void util_mouse_encode(uint8_t* data,
-		int16_t x, int16_t y, uint8_t buttons)
+void util_mouse_encode(uint8_t* data, uint8_t rshift,
+		int32_t x, int32_t y, uint8_t buttons)
 {
-	uint16_t ix = x;
-	uint16_t iy = y;
+	uint32_t ix = x;
+	uint32_t iy = y;
+
+	if (rshift > 16) rshift = 16;
+	if (rshift > 0)
+	{
+		ix >>= rshift;
+		iy >>= rshift;
+	}
 
 	data[0] = iy & 0x7F;
 	data[1] = ix & 0x7F;

--- a/firmware/util.h
+++ b/firmware/util.h
@@ -58,11 +58,14 @@ uint8_t util_mouse_decode(uint8_t* data, uint8_t data_len,
  * just use bytes 0 and 1 in the array.
  *
  * @param data      output array of data values, at least 5 bytes long.
+ * @param rshift    number of bits to shift motion data to the right prior to
+ *                  encoding, to support fixed-point representations and/or
+ *                  simple scaling; 0 to not shift.
  * @param x         input X axis movement.
  * @param y         input Y axis movement.
  * @param buttons   input buttons, LSB button 1.
  */
-void util_mouse_encode(uint8_t* data,
-		int16_t x, int16_t y, uint8_t buttons);
+void util_mouse_encode(uint8_t* data, uint8_t rshift,
+		int32_t x, int32_t y, uint8_t buttons);
 
 #endif /* __UTIL_H__ */


### PR DESCRIPTION
Split up the implementation of drivers (facing the computers) and handlers (facing real ADB peripherals). Should allow for more code reuse and make things easier to read.